### PR TITLE
feat(wifi): implemented wifi menu item and no internet page in safari

### DIFF
--- a/src/components/apps/Safari.js
+++ b/src/components/apps/Safari.js
@@ -118,6 +118,37 @@ class NavPage extends Component {
   }
 }
 
+class NoInternetPage extends Component {
+  render() {
+    return (
+      <div
+        className="w-full safari-content bg-blue-50 overflow-y-scroll bg-center bg-cover"
+        style={{
+          backgroundImage: `url(${
+            this.props.dark ? wallpapers.night : wallpapers.day
+          })`
+        }}
+      >
+        <div className="w-full h-full bg-gray-100 bg-opacity-80 blur flex items-center justify-center">
+          <div
+            className={`pb-10 text-center ${
+              this.props.dark ? "text-gray-500" : "text-gray-600"
+            }`}
+          >
+            <div className="text-2xl font-bold">
+              You Are Not Connected to the Internet
+            </div>
+            <div className="pt-4 text-sm">
+              This page can't be displayed because your computer is currently
+              offline.
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
 class Safari extends Component {
   constructor(props) {
     super(props);
@@ -201,19 +232,23 @@ class Safari extends Component {
         </div>
 
         {/* browser content */}
-        {this.state.goURL === "" ? (
-          <NavPage
-            setGoURL={this.setGoURL}
-            width={this.props.width}
-            dark={this.props.dark}
-          />
+        {this.props.wifi ? (
+          this.state.goURL === "" ? (
+            <NavPage
+              setGoURL={this.setGoURL}
+              width={this.props.width}
+              dark={this.props.dark}
+            />
+          ) : (
+            <iframe
+              title={"Safari clone browser"}
+              src={this.state.goURL}
+              frameBorder="0"
+              className="safari-content w-full"
+            />
+          )
         ) : (
-          <iframe
-            title={"Safari clone browser"}
-            src={this.state.goURL}
-            frameBorder="0"
-            className="safari-content w-full"
-          />
+          <NoInternetPage />
         )}
       </div>
     );
@@ -222,7 +257,8 @@ class Safari extends Component {
 
 const mapStateToProps = (state) => {
   return {
-    dark: state.dark
+    dark: state.dark,
+    wifi: state.wifi
   };
 };
 

--- a/src/components/menus/TopBar.js
+++ b/src/components/menus/TopBar.js
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 import format from "date-fns/format";
 
 import AppleMenu from "./AppleMenu";
+import WifiMenu from "./WifiMenu";
 import ControlCenterMenu from "./ControlCenterMenu";
 import { isFullScreen } from "../../utils/screen";
 import { setVolume, setBrightness, toggleFullScreen } from "../../redux/action";
@@ -12,6 +13,7 @@ import music from "../../configs/music";
 import { BsBatteryFull } from "react-icons/bs";
 import { BiSearch } from "react-icons/bi";
 import { FaWifi } from "react-icons/fa";
+import { RiSignalWifiLine } from "react-icons/ri";
 import { AiFillApple } from "react-icons/ai";
 
 const TopBarItem = forwardRef((props, ref) => {
@@ -36,6 +38,7 @@ class TopBar extends Component {
     this.state = {
       date: new Date(),
       showControlCenter: false,
+      showWifiMenu: false,
       showAppleMenu: false,
       playing: false
     };
@@ -47,6 +50,7 @@ class TopBar extends Component {
     this.toggleAudio = this.toggleAudio.bind(this);
     this.appleBtnRef = createRef();
     this.controlCenterBtnRef = createRef();
+    this.wifiBtnRef = createRef();
     this.spotlightBtnRef = createRef();
     this.resize.bind(this);
   }
@@ -113,6 +117,12 @@ class TopBar extends Component {
     });
   };
 
+  toggleWifiMenu = () => {
+    this.setState({
+      showWifiMenu: !this.state.showWifiMenu
+    });
+  };
+
   logout = () => {
     this.toggleAudio(false);
     this.props.setLogin(false);
@@ -166,8 +176,16 @@ class TopBar extends Component {
             <span className="text-xs mt-0.5 mr-1">100%</span>
             <BsBatteryFull size={20} />
           </TopBarItem>
-          <TopBarItem hideOnMobile={true}>
-            <FaWifi size={17} />
+          <TopBarItem
+            hideOnMobile={true}
+            onClick={this.toggleWifiMenu}
+            ref={this.wifiBtnRef}
+          >
+            {this.props.wifi ? (
+              <FaWifi size={17} />
+            ) : (
+              <RiSignalWifiLine size={17} />
+            )}
           </TopBarItem>
           <TopBarItem
             ref={this.spotlightBtnRef}
@@ -185,6 +203,14 @@ class TopBar extends Component {
               alt="control center"
             />
           </TopBarItem>
+
+          {/* Open this when clicking on Wifi button */}
+          {this.state.showWifiMenu && (
+            <WifiMenu
+              toggleWifiMenu={this.toggleWifiMenu}
+              btnRef={this.wifiBtnRef}
+            />
+          )}
 
           {/* Open this when clicking on Control Center button */}
           {this.state.showControlCenter && (
@@ -210,7 +236,8 @@ class TopBar extends Component {
 const mapStateToProps = (state) => {
   return {
     volume: state.volume,
-    brightness: state.brightness
+    brightness: state.brightness,
+    wifi: state.wifi
   };
 };
 

--- a/src/components/menus/WifiMenu.js
+++ b/src/components/menus/WifiMenu.js
@@ -3,9 +3,6 @@ import { connect } from "react-redux";
 import "react-rangeslider/lib/index.css";
 import { toggleWIFI } from "../../redux/action";
 
-// ------- import icons -------
-import { FaWifi } from "react-icons/fa";
-
 class WifiMenu extends Component {
   constructor(props) {
     super(props);

--- a/src/components/menus/WifiMenu.js
+++ b/src/components/menus/WifiMenu.js
@@ -1,0 +1,64 @@
+import React, { Component, createRef } from "react";
+import { connect } from "react-redux";
+import "react-rangeslider/lib/index.css";
+import { toggleWIFI } from "../../redux/action";
+
+// ------- import icons -------
+import { FaWifi } from "react-icons/fa";
+
+class WifiMenu extends Component {
+  constructor(props) {
+    super(props);
+    this.wifiRef = createRef();
+    this.handleClickOutside = this.handleClickOutside.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener("mousedown", this.handleClickOutside);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("mousedown", this.handleClickOutside);
+  }
+
+  handleClickOutside(e) {
+    if (
+      this.wifiRef &&
+      !this.wifiRef.current.contains(e.target) &&
+      !this.props.btnRef.current.contains(e.target)
+    )
+      this.props.toggleWifiMenu();
+  }
+
+  render() {
+    return (
+      <div
+        className="fixed w-80 max-w-full top-8 right-0 sm:right-2 z-50 p-2 flex gap-2 bg-white bg-opacity-40 blur rounded-2xl text-black shadow-2xl"
+        ref={this.wifiRef}
+      >
+        <div className="w-4/5 p-2 font-medium">Wi-Fi</div>
+        <div className="w-1/5 p-2">
+          <label class="switch-toggle">
+            <input
+              type="checkbox"
+              checked={this.props.wifi}
+              onClick={() => this.props.toggleWIFI(!this.props.wifi)}
+            />
+            <span class="slider-toggle round"></span>
+          </label>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    dark: state.dark,
+    wifi: state.wifi
+  };
+};
+
+export default connect(mapStateToProps, {
+  toggleWIFI
+})(WifiMenu);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -308,3 +308,71 @@ body:not(pre) {
 .dark .bear .sidebar {
   @apply bg-gray-700 text-white;
 }
+
+
+/*
+  Credits: W3 Schools: https://www.w3schools.com/howto/howto_css_switch.asp
+*/
+
+/* The switch - the box around the slider */
+.switch-toggle {
+  position: relative;
+  display: inline-block;
+  width: 30px;
+  height: 17px;
+}
+
+/* Hide default HTML checkbox */
+.switch-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* The slider */
+.slider-toggle {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider-toggle:before {
+  position: absolute;
+  content: "";
+  height: 13px;
+  width: 13px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider-toggle {
+  background-color: #2196F3;
+}
+
+input:focus + .slider-toggle {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider-toggle:before {
+  -webkit-transform: translateX(13px);
+  -ms-transform: translateX(13px);
+  transform: translateX(13px);
+}
+
+/* Rounded sliders */
+.slider-toggle.round {
+  border-radius: 17px;
+}
+
+.slider-toggle.round:before {
+  border-radius: 50%;
+}


### PR DESCRIPTION
Thought it would be cool to have turning off the wifi also turn off internet connection with Safari. This renders the default macOS no internet page if wifi is turned off and adds a menu item to also toggle the wifi (can be expanded to add different networks).


![result](https://user-images.githubusercontent.com/8171838/117610283-776acf80-b12f-11eb-952c-f200363edc6d.gif)
